### PR TITLE
Remove manually set proxy settings

### DIFF
--- a/blackduck/Client.py
+++ b/blackduck/Client.py
@@ -50,11 +50,6 @@ class HubSession(requests.Session):
         self.mount("http://", adapter)
         logger.info("Using a session with a %s second timeout and up to %s retries per request", timeout, retries)
 
-        self.proxies.update({
-            'http': os.environ.get('http_proxy', ''),
-            'https': os.environ.get('https_proxy', '')
-        })
-
     def request(self, method, url, **kwargs):
         kwargs['timeout'] = self._timeout
 
@@ -74,7 +69,7 @@ class HubSession(requests.Session):
 
 class Client:
     """A binding to Blackduck's REST API that provides a robust connection backed by a session object.
-    A base URL, timeout, retries, proxies, and TLS verification are set upon initialization and these
+    A base URL, timeout, retries, and TLS verification are set upon initialization and these
     attributes are persisted across all requests.
 
     At the REST API level, it provides a consistent way to discover and traverse public resources,


### PR DESCRIPTION
Setting proxy settings for the `requests` session manually from the environment variables is not necessary, since `requests` handles it [itself](https://docs.python-requests.org/en/latest/user/advanced/#proxies).

> When the proxies configuration is not overridden per request as shown above, Requests relies on the proxy configuration defined by standard environment variables http_proxy, https_proxy, no_proxy, and all_proxy. Uppercase variants of these variables are also supported.

In fact the way it is currently implemented the contents of the `no_proxy` variable is ignored, preventing the following common use case:

```
export https_proxy="http://proxy.corporate-network.com:9980"
export no_proxy=".corporate-network.com"

bd = Client(
    token=os.environ.get('blackduck_token'),
    base_url="https://blackduck.corporate-network.com")
```

Results in a connection error depending on the proxy behavior. Some proxies redirect, some proxies just hang up. The latter is the case especially when the proxy is not located inside the corporate network.

This change just removes the redundant proxy setup code so that `requests` can handle all proxy setup itself.